### PR TITLE
Try to Fix the Ubuntu 20 compatibility issue with __cxx11::string qualifiers

### DIFF
--- a/libcyberradio/include/LibCyberRadio/Driver/NDR551/DataPort.h
+++ b/libcyberradio/include/LibCyberRadio/Driver/NDR551/DataPort.h
@@ -14,6 +14,7 @@
 #include "LibCyberRadio/Driver/DataPort.h"
 #include <jsoncpp/json/json.h>
 #include <boost/lexical_cast.hpp>
+#include <string>
 
 /**
  * \brief Provides programming elements for controlling CyberRadio Solutions products.
@@ -134,7 +135,7 @@ namespace LibCyberRadio
                             unsigned int& sourcePort,
                             unsigned int& destPort);
 
-                    std::__cxx11::string _sourceMacAddr;
+                    std::string _sourceMacAddr;
                     uint16_t _sourcePort;
 
             }; /* class DataPort */

--- a/libcyberradio/libcyberradio/Driver/NDR551/DataPort.cpp
+++ b/libcyberradio/libcyberradio/Driver/NDR551/DataPort.cpp
@@ -80,8 +80,8 @@ namespace LibCyberRadio
                 Json::Value returnVal; 
                 std::string t = rsp.at(0);
                 bool parsingSuccessful = reader.parse( t.c_str(), returnVal );     //parse process
-                _sourceIP = boost::lexical_cast<std::__cxx11::string>(returnVal["result"]["ip"].asString());
-                _sourceMacAddr = boost::lexical_cast<std::__cxx11::string>(returnVal["result"]["mac"].asString());
+                _sourceIP = boost::lexical_cast<std::string>(returnVal["result"]["ip"].asString());
+                _sourceMacAddr = boost::lexical_cast<std::string>(returnVal["result"]["mac"].asString());
                 _sourcePort = boost::lexical_cast<uint16_t>(returnVal["result"]["port"].asUInt());
                 for(int i = _dipEntryIndexBase; i < _numDipEntries; i++ )
                 {
@@ -111,7 +111,7 @@ namespace LibCyberRadio
                 bool parsingSuccessful = reader.parse( t.c_str(), returnVal );     //parse process
                 ret = returnVal["success"].asBool();
                 if(ret){
-                    ipAddr = boost::lexical_cast<std::__cxx11::string>(returnVal["result"]["ip"].asString());
+                    ipAddr = boost::lexical_cast<std::string>(returnVal["result"]["ip"].asString());
                 } else {
                     ipAddr = "0.0.0.0";
                 }
@@ -170,8 +170,8 @@ namespace LibCyberRadio
                     ret = returnVal["success"].asBool();
                     if(ret)
                     {
-                        ipAddr = boost::lexical_cast<std::__cxx11::string>(returnVal["result"]["ip"].asString());
-                        macAddr = boost::lexical_cast<std::__cxx11::string>(returnVal["result"]["mac"].asString());
+                        ipAddr = boost::lexical_cast<std::string>(returnVal["result"]["ip"].asString());
+                        macAddr = boost::lexical_cast<std::string>(returnVal["result"]["mac"].asString());
                         //sourcePort = boost::lexical_cast<uint16_t>(returnVal["result"]["port"].asUInt());
                         sourcePort = 0;
                         destPort = boost::lexical_cast<uint16_t>(returnVal["result"]["port"].asUInt());

--- a/libcyberradio/libcyberradio/Driver/RadioTransport.cpp
+++ b/libcyberradio/libcyberradio/Driver/RadioTransport.cpp
@@ -530,7 +530,7 @@ namespace LibCyberRadio
                 this->debug("[receiveJsonUdp] Parsing JSON Error\n");
             }
             Json::FastWriter fastWriter;
-            std::__cxx11::string output = fastWriter.write(root);
+            std::string output = fastWriter.write(root);
             ret.push_back(output);
             return ret;
         }


### PR DESCRIPTION
Looks like the newest GCC need __cxx11::basic_string instead, just move to std::string for compat