### PR TITLE
GitHub/sync/01 24 22a

### DIFF
--- a/libcyberradio/CMakeLists.txt
+++ b/libcyberradio/CMakeLists.txt
@@ -7,7 +7,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 # NOTE: Update this default package version string when there is a 
 #    new library release!
 IF("${PACKAGE_VERSION}" STREQUAL "")
-   SET(PACKAGE_VERSION "22.01.06"
+   SET(PACKAGE_VERSION "22.01.24"
        CACHE STRING "Package version number" FORCE)
 ENDIF("${PACKAGE_VERSION}" STREQUAL "")
 

--- a/libcyberradio/CMakeLists.txt
+++ b/libcyberradio/CMakeLists.txt
@@ -18,7 +18,7 @@ SET(PROJECT_NAME "libcyberradio"
 SET(PROJECT_VERSION ${PACKAGE_VERSION}
     CACHE STRING "Project version number" FORCE)
 
-OPTION(BuildExamples "Examples" ON)
+OPTION(BuildExamples "Examples" OFF)
 IF ( BuildExamples )
     SET(EXAMPLES_ENABLED ON)
 ELSE()

--- a/libcyberradio/examples/CMakeLists.txt
+++ b/libcyberradio/examples/CMakeLists.txt
@@ -209,5 +209,5 @@ IF( EXAMPLES_ENABLED )
                 DESTINATION ${LIBCYBERRADIO_EXAMPLES_DIR}
         )
 ELSE()
-        MESSAGE(STATUS "Use -DXMAPLES_ENABLED=TRUE to enable building Examples")        
+        MESSAGE(STATUS "Use -DEXMAPLES_ENABLED=TRUE to enable building Examples")        
 ENDIF( EXAMPLES_ENABLED )        

--- a/libcyberradio/examples/CMakeLists.txt
+++ b/libcyberradio/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 IF( EXAMPLES_ENABLED )
-
+        MESSAGE(STATUS "Examples Enabled, use -DBuildExamples=OFF to disble building Examples") 
         ########################################################################
         # Example Applications
         ########################################################################
@@ -208,6 +208,5 @@ IF( EXAMPLES_ENABLED )
         INSTALL(FILES ${ndr324example_sources}
                 DESTINATION ${LIBCYBERRADIO_EXAMPLES_DIR}
         )
-ELSE()
-        MESSAGE(STATUS "Use -DEXMAPLES_ENABLED=TRUE to enable building Examples")        
+               
 ENDIF( EXAMPLES_ENABLED )        

--- a/libcyberradio/version.txt
+++ b/libcyberradio/version.txt
@@ -1,2 +1,2 @@
 libcyberradio
-22.01.20a
+22.01.24


### PR DESCRIPTION
Fixed the examples to default to OFF and message indicating how to turn them off when on.